### PR TITLE
Suggestion: 「展開を準備する」→「デプロイのための準備」("Prepare for deployment" )

### DIFF
--- a/articles/bot-builder-deploy-az-cli.md
+++ b/articles/bot-builder-deploy-az-cli.md
@@ -31,7 +31,7 @@ ms.locfileid: "82158816"
 
 [!INCLUDE [deploy prerequisite](~/includes/deploy/snippet-prerequisite.md)]
 
-## <a name="prepare-for-deployment"></a>デプロイのための準備
+## <a name="prepare-for-deployment"></a>デプロイを準備する
 
 [!INCLUDE [deploy prepare intro](~/includes/deploy/snippet-prepare-deploy-intro.md)]
 

--- a/articles/bot-builder-deploy-az-cli.md
+++ b/articles/bot-builder-deploy-az-cli.md
@@ -31,7 +31,7 @@ ms.locfileid: "82158816"
 
 [!INCLUDE [deploy prerequisite](~/includes/deploy/snippet-prerequisite.md)]
 
-## <a name="prepare-for-deployment"></a>展開を準備する
+## <a name="prepare-for-deployment"></a>デプロイのための準備
 
 [!INCLUDE [deploy prepare intro](~/includes/deploy/snippet-prepare-deploy-intro.md)]
 


### PR DESCRIPTION
見出し "Prepare for deployment" が「展開を準備する」となっていますが、これは「デプロイのための準備」のほうが自然な日本語訳だと思いました。
（後に続く小見出しも「デプロイする準備が完了したボット」となり、deploy を「展開」ではなく「デプロイ」と訳されていますし、統一したほうが良さそうです）
The h2 "Prepare for deployment" is translated to "展開を準備する", but I think it seems "デプロイのための準備" is better. Its following header "デプロイする準備が完了したボット" is also translated from "deploy", ("deploy" -> "デプロイ") so I guess "Prepare for deployment" also should be "**デプロイ** のための準備" (not "**展開** を準備").